### PR TITLE
add:テストケース03、04修正

### DIFF
--- a/test_code_creation_name/src/test/java/jp/co/sss/lms/ct/f01_login1/Case01.java
+++ b/test_code_creation_name/src/test/java/jp/co/sss/lms/ct/f01_login1/Case01.java
@@ -1,7 +1,8 @@
 package jp.co.sss.lms.ct.f01_login1;
 
 import static jp.co.sss.lms.ct.util.WebDriverUtils.*;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -96,6 +97,8 @@ public class Case01 {
 		Case01 instance = new Case01();
 
 		getEvidence(instance);
+
+		assertEquals("ログイン | LMS", getTitle());
 
 		// セッション情報を事前に設定する場合、MockHttpSessionを使用する
 		MockHttpSession session = new MockHttpSession();

--- a/test_code_creation_name/src/test/java/jp/co/sss/lms/ct/f01_login1/Case02.java
+++ b/test_code_creation_name/src/test/java/jp/co/sss/lms/ct/f01_login1/Case02.java
@@ -1,7 +1,8 @@
 package jp.co.sss.lms.ct.f01_login1;
 
 import static jp.co.sss.lms.ct.util.WebDriverUtils.*;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -95,6 +96,8 @@ public class Case02 {
 
 		getEvidence(instance);
 
+		assertEquals("ログイン | LMS", getTitle());
+
 		//		// URLが「/」のgetメソッドを実行する
 		//		ResultActions results = mockMvc.perform(get("/"));
 		//
@@ -138,6 +141,8 @@ public class Case02 {
 		suffix = "02_ログイン後(未登録ユーザー)";
 
 		getEvidence(instance, suffix);
+
+		assertEquals("ログイン | LMS", getTitle());
 
 		// ログイン情報
 		String loginuserId = "noUser";

--- a/test_code_creation_name/src/test/java/jp/co/sss/lms/ct/f01_login1/Case03.java
+++ b/test_code_creation_name/src/test/java/jp/co/sss/lms/ct/f01_login1/Case03.java
@@ -1,7 +1,8 @@
 package jp.co.sss.lms.ct.f01_login1;
 
 import static jp.co.sss.lms.ct.util.WebDriverUtils.*;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -98,6 +99,8 @@ public class Case03 {
 		Case03 instance = new Case03();
 
 		getEvidence(instance);
+
+		assertEquals("ログイン | LMS", getTitle());
 	}
 
 	@Test
@@ -136,6 +139,8 @@ public class Case03 {
 		suffix = "02_ログイン後(登録済ユーザー)";
 
 		getEvidence(instance, suffix);
+
+		assertEquals("コース詳細 | LMS", getTitle());
 
 		//JUnit
 

--- a/test_code_creation_name/src/test/java/jp/co/sss/lms/ct/f02_faq/Case04.java
+++ b/test_code_creation_name/src/test/java/jp/co/sss/lms/ct/f02_faq/Case04.java
@@ -1,7 +1,8 @@
 package jp.co.sss.lms.ct.f02_faq;
 
 import static jp.co.sss.lms.ct.util.WebDriverUtils.*;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -97,6 +98,8 @@ public class Case04 {
 		Case04 instance = new Case04();
 
 		getEvidence(instance);
+
+		assertEquals("ログイン | LMS", getTitle());
 	}
 
 	@Test
@@ -115,6 +118,8 @@ public class Case04 {
 		suffix = "01_ログイン前(登録済ユーザー)";
 
 		getEvidence(instance, suffix);
+
+		assertEquals("ログイン | LMS", getTitle());
 
 		// ユーザー名とパスワードを入力
 
@@ -135,6 +140,8 @@ public class Case04 {
 		suffix = "02_ログイン後(登録済ユーザー)";
 
 		getEvidence(instance, suffix);
+
+		assertEquals("コース詳細 | LMS", getTitle());
 	}
 
 	@Test
@@ -165,6 +172,8 @@ public class Case04 {
 		suffix = "03_ヘルプ画面遷移";
 
 		getEvidence(instance, suffix);
+
+		assertEquals("ヘルプ | LMS", getTitle());
 	}
 
 	@Test
@@ -190,6 +199,8 @@ public class Case04 {
 
 		getEvidence(instance, suffix);
 
+		assertEquals("ヘルプ | LMS", getTitle());
+
 		// 指定のURLの画面を開く
 		goTo("http://localhost:8080/lms/faq");
 		scrollTo(0);
@@ -199,6 +210,8 @@ public class Case04 {
 		suffix = "04-2_よくある質問画面遷移(絶対パスでクリック)";
 
 		WebDriverUtils.getEvidence(instance, suffix);
+
+		assertEquals("よくある質問 | LMS", getTitle());
 
 		// モック対象メソッドの返却値を設定
 		when(loginUserUtil.isLogin()).thenReturn(true);

--- a/test_code_creation_name/src/test/java/jp/co/sss/lms/ct/util/WebDriverUtils.java
+++ b/test_code_creation_name/src/test/java/jp/co/sss/lms/ct/util/WebDriverUtils.java
@@ -117,6 +117,15 @@ public class WebDriverUtils {
 	}
 
 	/**
+	 * タイトル取得
+	 * @return 
+	 */
+	public static String getTitle() {
+		String title = webDriver.getTitle();
+		return title;
+	}
+
+	/**
 	 * ログインID取得
 	 */
 	public static WebElement getUserName() {


### PR DESCRIPTION
add:テストケース03、04修正

テストケース03、04について、ページ遷移した後に確実に該当ページであることを確認するために
タイトル情報を取得してアサーションで確認するテストケースを追加した。